### PR TITLE
fix: preserve 'v' prefix in Docker tags for semantic versioning

### DIFF
--- a/workflow-changes.md
+++ b/workflow-changes.md
@@ -1,0 +1,80 @@
+# Workflow Changes to Preserve 'v' Prefix in Docker Tags
+
+This document contains the changes needed to ensure Docker tags include the 'v' prefix (e.g., v2.0.0 instead of 2.0.0).
+
+## Changes to `.github/workflows/deploy-to-ecr.yml`
+
+In the "Extract metadata" step (around line 173), update the semver patterns:
+
+### Before:
+```yaml
+tags: |
+  # Always update latest on main branch pushes
+  type=raw,value=latest,enable={{is_default_branch}}
+  # Git SHA for immutable reference
+  type=sha,prefix=sha-,format=short
+  # Timestamp for chronological ordering
+  type=raw,value={{date 'YYYYMMDD-HHmmss'}},prefix=build-
+  # Semantic versioning (if you create git tags)
+  type=semver,pattern={{version}}
+  type=semver,pattern={{major}}.{{minor}}
+  # Branch name (sanitized)
+  type=ref,event=branch
+  # PR number (if triggered by PR)
+  type=ref,event=pr
+```
+
+### After:
+```yaml
+tags: |
+  # Always update latest on main branch pushes
+  type=raw,value=latest,enable={{is_default_branch}}
+  # Git SHA for immutable reference
+  type=sha,prefix=sha-,format=short
+  # Timestamp for chronological ordering
+  type=raw,value={{date 'YYYYMMDD-HHmmss'}},prefix=build-
+  # Semantic versioning (preserve 'v' prefix from git tags)
+  type=semver,pattern={{raw}}
+  type=semver,pattern=v{{major}}.{{minor}}
+  # Branch name (sanitized)
+  type=ref,event=branch
+  # PR number (if triggered by PR)
+  type=ref,event=pr
+```
+
+## Changes to `.github/workflows/release.yml`
+
+In the "Summary" step (around line 155), update the Docker tag documentation:
+
+### Before:
+```yaml
+echo "### Docker Image Tags"
+echo "The ECR deployment workflow will automatically create the following tags:"
+echo "- \`${NEW_VERSION#v}\` (full version)"
+echo "- \`${NEW_VERSION#v%.*}\` (major.minor)"
+echo "- \`${NEW_VERSION#v%%.*}\` (major only)"
+echo "- \`latest\`"
+echo "- \`sha-${GITHUB_SHA:0:7}\`"
+```
+
+### After:
+```yaml
+echo "### Docker Image Tags"
+echo "The ECR deployment workflow will automatically create the following tags:"
+echo "- \`$NEW_VERSION\` (full version with v prefix)"
+echo "- \`v${NEW_VERSION#v%%.*}.${NEW_VERSION#v*.}\` (major.minor with v prefix)"
+echo "- \`latest\`"
+echo "- \`sha-${GITHUB_SHA:0:7}\`"
+echo "- \`build-YYYYMMDD-HHmmss\`"
+```
+
+## Summary of Changes
+
+1. **deploy-to-ecr.yml**: Changed `pattern={{version}}` to `pattern={{raw}}` to preserve the 'v' prefix
+2. **deploy-to-ecr.yml**: Changed `pattern={{major}}.{{minor}}` to `pattern=v{{major}}.{{minor}}` to add 'v' prefix to major.minor tags
+3. **release.yml**: Updated the summary output to correctly show that Docker tags will include the 'v' prefix
+
+These changes will ensure that:
+- Git tag `v3.0.0` → Docker tags `v3.0.0`, `v3.0`, `latest`, etc.
+- The 'v' prefix is preserved throughout the tagging process
+- Kubernetes manifests can correctly reference images with the 'v' prefix


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions workflows to preserve the 'v' prefix in Docker tags when creating releases. Currently, Git tags like `v3.0.0` result in Docker tags without the prefix (e.g., `3.0.0`). This change ensures Docker tags match Git tags exactly.

## Changes Required

Due to GitHub API security restrictions, I couldn't directly modify the workflow files. Please manually apply the changes documented in the `workflow-changes.md` file in this PR.

### Files to Update:
1. `.github/workflows/deploy-to-ecr.yml` - Update the semver patterns in the metadata extraction step
2. `.github/workflows/release.yml` - Update the summary output to reflect the new tag format

## Key Changes:

### deploy-to-ecr.yml
- Change `type=semver,pattern={{version}}` to `type=semver,pattern={{raw}}`
- Change `type=semver,pattern={{major}}.{{minor}}` to `type=semver,pattern=v{{major}}.{{minor}}`

### release.yml
- Update the summary to show Docker tags will include the 'v' prefix

## Result

After these changes:
- Git tag `v3.0.0` → Docker tags `v3.0.0`, `v3.0`, `latest`, etc.
- Kubernetes manifests can correctly reference images with the 'v' prefix (e.g., `image: myrepo:v2.0.0`)

## Testing

The changes can be tested by creating a new release and verifying that the Docker tags in ECR include the 'v' prefix.

---

Please review the `workflow-changes.md` file for the exact changes needed and apply them manually to the workflow files.