### PR TITLE
Fix chore pagination bug - show all chores functionality

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -394,7 +394,8 @@ async def get_chores_html(
 async def get_available_chores_html(
     request: Request,
     db: AsyncSession = Depends(get_db),
-    current_user: models.User = Depends(get_current_user)
+    current_user: models.User = Depends(get_current_user),
+    show_all: bool = Query(False)
 ):
     """Get HTML for available chores (child view)."""
     # Only for children
@@ -410,7 +411,7 @@ async def get_available_chores_html(
     
     return templates.TemplateResponse(
         "components/chore_list.html", 
-        {"request": request, "chores": chores, "current_user": current_user}
+        {"request": request, "chores": chores, "current_user": current_user, "show_all": show_all, "target_id": "available-chores"}
     )
 
 @app.get("/api/v1/html/chores/pending", response_class=HTMLResponse)

--- a/backend/app/templates/components/chore_list.html
+++ b/backend/app/templates/components/chore_list.html
@@ -1,12 +1,25 @@
 {% if chores %}
-    {% for chore in chores[:10] %}
-        {% include "components/chore_item.html" %}
-    {% endfor %}
-    {% if chores|length > 10 %}
-    <div class="mt-4 text-center">
-        <p class="text-gray-600 text-sm">Showing 10 of {{ chores|length }} chores</p>
-        <a href="/chores" class="text-blue-600 hover:text-blue-700 underline">View all chores</a>
-    </div>
+    {% if show_all %}
+        {% for chore in chores %}
+            {% include "components/chore_item.html" %}
+        {% endfor %}
+    {% else %}
+        {% for chore in chores[:10] %}
+            {% include "components/chore_item.html" %}
+        {% endfor %}
+        {% if chores|length > 10 %}
+        <div class="mt-4 text-center">
+            <p class="text-gray-600 text-sm">Showing 10 of {{ chores|length }} chores</p>
+            <button 
+                class="text-blue-600 hover:text-blue-700 underline cursor-pointer"
+                hx-get="{{ request.url.path }}?show_all=true"
+                hx-target="#{{ target_id|default('available-chores') }}"
+                hx-swap="innerHTML"
+            >
+                Show all chores
+            </button>
+        </div>
+        {% endif %}
     {% endif %}
 {% else %}
     <p class="text-gray-500 italic">No chores found.</p>


### PR DESCRIPTION
- Updated chore_list.html template to support "show all" functionality
- Changed "View all chores" link to "Show all chores" button with HTMX
- Added show_all parameter to /api/v1/html/chores/available endpoint
- Fixed circular navigation issue where pagination link redirected to same page

The pagination now correctly displays all chores when "Show all chores" is clicked, instead of being limited to 10 items with a non-functional link.

🤖 Generated with [Claude Code](https://claude.ai/code)