### PR TITLE
Fix pending approvals not loading on parent dashboard

### DIFF
--- a/backend/app/templates/pages/dashboard.html
+++ b/backend/app/templates/pages/dashboard.html
@@ -65,6 +65,7 @@
             <div 
                 id="pending-chores"
                 hx-get="/api/v1/html/chores/pending-approval"
+                hx-trigger="load"
                 hx-swap="innerHTML"
             >
                 <p class="text-gray-500">Loading pending chores...</p>


### PR DESCRIPTION
The pending approval section was missing the hx-trigger="load" attribute, preventing HTMX from automatically loading pending chores when the page loads. Added the missing attribute to ensure pending chores are displayed correctly when parents view their dashboard.

🤖 Generated with [Claude Code](https://claude.ai/code)