### PR TITLE
Fix CI test failure after children dropdown endpoint fix

### DIFF
--- a/backend/tests/api/v1/test_htmx_endpoints.py
+++ b/backend/tests/api/v1/test_htmx_endpoints.py
@@ -61,7 +61,21 @@ async def test_children_options_endpoint(client: AsyncClient, parent_token, test
         headers={"Authorization": f"Bearer {parent_token}"}
     )
     assert response.status_code == 200
-    # Updated test to match new clickable card format
+    # Test expects dropdown options, not clickable cards
+    assert b"<option" in response.content
+    assert b"Select a child" in response.content
+    assert str(test_child_user.id).encode() in response.content
+    assert test_child_user.username.encode() in response.content
+
+@pytest.mark.asyncio
+async def test_children_cards_endpoint(client: AsyncClient, parent_token, test_child_user):
+    """Test the children cards endpoint for dashboard."""
+    response = await client.get(
+        "/api/v1/users/children-cards", 
+        headers={"Authorization": f"Bearer {parent_token}"}
+    )
+    assert response.status_code == 200
+    # Test expects clickable cards for dashboard
     assert b"Click to view chores" in response.content
     assert str(test_child_user.id).encode() in response.content
     assert test_child_user.username.encode() in response.content


### PR DESCRIPTION
- Updated test_children_options_endpoint to expect dropdown options
- Added new test_children_cards_endpoint for the card view
- Tests now properly validate the separated endpoints:
  - /api/v1/users/children returns dropdown options
  - /api/v1/users/children-cards returns clickable cards

This fixes the CI pipeline failure that occurred after fixing the assignee dropdown bug where the endpoint was returning cards instead of options.